### PR TITLE
Hybrid: remove shared ptrs

### DIFF
--- a/gtsam/hybrid/IncrementalHybrid.cpp
+++ b/gtsam/hybrid/IncrementalHybrid.cpp
@@ -51,8 +51,9 @@ void IncrementalHybrid::update(GaussianHybridFactorGraph graph,
 
   // Eliminate partially.
   HybridBayesNet::shared_ptr bayesNetFragment;
-  std::tie(bayesNetFragment, remainingFactorGraph_) =
-      graph.eliminatePartialSequential(ordering);
+  auto result = graph.eliminatePartialSequential(ordering);
+  bayesNetFragment = result.first;
+  remainingFactorGraph_ = *result.second;
 
   // Add the partial bayes net to the posterior bayes net.
   hybridBayesNet_.push_back<HybridBayesNet>(*bayesNetFragment);
@@ -65,7 +66,7 @@ void IncrementalHybrid::update(GaussianHybridFactorGraph graph,
         boost::dynamic_pointer_cast<GaussianMixture>(hybridBayesNet_.back());
 
     auto discreteFactor = boost::dynamic_pointer_cast<DecisionTreeFactor>(
-        remainingFactorGraph_->discreteGraph().at(0));
+        remainingFactorGraph_.discreteGraph().at(0));
 
     // Let's assume that the structure of the last discrete density will be the
     // same as the last continuous
@@ -126,7 +127,7 @@ GaussianMixture::shared_ptr IncrementalHybrid::gaussianMixture(
 
 /* ************************************************************************* */
 const DiscreteFactorGraph &IncrementalHybrid::remainingDiscreteGraph() const {
-  return remainingFactorGraph_->discreteGraph();
+  return remainingFactorGraph_.discreteGraph();
 }
 
 /* ************************************************************************* */
@@ -135,7 +136,7 @@ const HybridBayesNet &IncrementalHybrid::hybridBayesNet() const {
 }
 
 /* ************************************************************************* */
-GaussianHybridFactorGraph::shared_ptr IncrementalHybrid::remainingFactorGraph()
+const GaussianHybridFactorGraph &IncrementalHybrid::remainingFactorGraph()
     const {
   return remainingFactorGraph_;
 }

--- a/gtsam/hybrid/IncrementalHybrid.h
+++ b/gtsam/hybrid/IncrementalHybrid.h
@@ -24,7 +24,7 @@ namespace gtsam {
 
 class IncrementalHybrid {
  private:
-  HybridBayesNet::shared_ptr hybridBayesNet_;
+  HybridBayesNet hybridBayesNet_;
   GaussianHybridFactorGraph::shared_ptr remainingFactorGraph_;
 
  public:
@@ -57,13 +57,13 @@ class IncrementalHybrid {
   const DiscreteFactorGraph& remainingDiscreteGraph() const;
 
   /// Return the Bayes Net posterior.
-  HybridBayesNet::shared_ptr hybridBayesNet() const;
+  const HybridBayesNet& hybridBayesNet() const;
 
   /**
    * @brief Return the leftover factor graph after the last update with the
    * specified ordering.
    *
-   * @return GaussianHybridFactorGraph::shared_ptr
+   * @return GaussianHybridFactorGraph
    */
   GaussianHybridFactorGraph::shared_ptr remainingFactorGraph() const;
 };

--- a/gtsam/hybrid/IncrementalHybrid.h
+++ b/gtsam/hybrid/IncrementalHybrid.h
@@ -25,7 +25,7 @@ namespace gtsam {
 class IncrementalHybrid {
  private:
   HybridBayesNet hybridBayesNet_;
-  GaussianHybridFactorGraph::shared_ptr remainingFactorGraph_;
+  GaussianHybridFactorGraph remainingFactorGraph_;
 
  public:
   /**
@@ -65,7 +65,7 @@ class IncrementalHybrid {
    *
    * @return GaussianHybridFactorGraph
    */
-  GaussianHybridFactorGraph::shared_ptr remainingFactorGraph() const;
+  const GaussianHybridFactorGraph& remainingFactorGraph() const;
 };
 
 };  // namespace gtsam

--- a/gtsam/hybrid/tests/testIncrementalHybrid.cpp
+++ b/gtsam/hybrid/tests/testIncrementalHybrid.cpp
@@ -68,11 +68,10 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_inference) {
   EXPECT(hybridBayesNet.at(1)->parents() == KeyVector({M(1)}));
 
   auto remainingFactorGraph = incrementalHybrid.remainingFactorGraph();
-  CHECK(remainingFactorGraph);
-  EXPECT_LONGS_EQUAL(1, remainingFactorGraph->size());
+  EXPECT_LONGS_EQUAL(1, remainingFactorGraph.size());
 
   auto discreteFactor_m1 = *dynamic_pointer_cast<DecisionTreeFactor>(
-      remainingFactorGraph->discreteGraph().at(0));
+      remainingFactorGraph.discreteGraph().at(0));
   EXPECT(discreteFactor_m1.keys() == KeyVector({M(1)}));
 
   GaussianHybridFactorGraph graph2;
@@ -98,11 +97,10 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_inference) {
   EXPECT(hybridBayesNet2.at(3)->parents() == KeyVector({M(2), M(1)}));
 
   auto remainingFactorGraph2 = incrementalHybrid.remainingFactorGraph();
-  CHECK(remainingFactorGraph2);
-  EXPECT_LONGS_EQUAL(1, remainingFactorGraph2->size());
+  EXPECT_LONGS_EQUAL(1, remainingFactorGraph2.size());
 
   auto discreteFactor = dynamic_pointer_cast<DecisionTreeFactor>(
-      remainingFactorGraph2->discreteGraph().at(0));
+      remainingFactorGraph2.discreteGraph().at(0));
   EXPECT(discreteFactor->keys() == KeyVector({M(2), M(1)}));
 
   ordering.clear();
@@ -227,11 +225,10 @@ TEST(DCGaussianElimination, Approx_inference) {
        1 1 1 Leaf    1 *
    */
   auto remainingFactorGraph = incrementalHybrid.remainingFactorGraph();
-  CHECK(remainingFactorGraph);
-  EXPECT_LONGS_EQUAL(1, remainingFactorGraph->size());
+  EXPECT_LONGS_EQUAL(1, remainingFactorGraph.size());
 
   auto discreteFactor_m1 = *dynamic_pointer_cast<DecisionTreeFactor>(
-      remainingFactorGraph->discreteGraph().at(0));
+      remainingFactorGraph.discreteGraph().at(0));
   EXPECT(discreteFactor_m1.keys() == KeyVector({M(3), M(2), M(1)}));
 
   // Check number of elements equal to zero

--- a/gtsam/hybrid/tests/testIncrementalHybrid.cpp
+++ b/gtsam/hybrid/tests/testIncrementalHybrid.cpp
@@ -61,12 +61,11 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_inference) {
   incrementalHybrid.update(graph1, ordering);
 
   auto hybridBayesNet = incrementalHybrid.hybridBayesNet();
-  CHECK(hybridBayesNet);
-  EXPECT_LONGS_EQUAL(2, hybridBayesNet->size());
-  EXPECT(hybridBayesNet->at(0)->frontals() == KeyVector{X(1)});
-  EXPECT(hybridBayesNet->at(0)->parents() == KeyVector({X(2), M(1)}));
-  EXPECT(hybridBayesNet->at(1)->frontals() == KeyVector{X(2)});
-  EXPECT(hybridBayesNet->at(1)->parents() == KeyVector({M(1)}));
+  EXPECT_LONGS_EQUAL(2, hybridBayesNet.size());
+  EXPECT(hybridBayesNet.at(0)->frontals() == KeyVector{X(1)});
+  EXPECT(hybridBayesNet.at(0)->parents() == KeyVector({X(2), M(1)}));
+  EXPECT(hybridBayesNet.at(1)->frontals() == KeyVector{X(2)});
+  EXPECT(hybridBayesNet.at(1)->parents() == KeyVector({M(1)}));
 
   auto remainingFactorGraph = incrementalHybrid.remainingFactorGraph();
   CHECK(remainingFactorGraph);
@@ -90,12 +89,13 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_inference) {
   incrementalHybrid.update(graph2, ordering2);
 
   auto hybridBayesNet2 = incrementalHybrid.hybridBayesNet();
-  CHECK(hybridBayesNet2);
-  EXPECT_LONGS_EQUAL(4, hybridBayesNet2->size());
-  EXPECT(hybridBayesNet2->at(2)->frontals() == KeyVector{X(2)});
-  EXPECT(hybridBayesNet2->at(2)->parents() == KeyVector({X(3), M(2), M(1)}));
-  EXPECT(hybridBayesNet2->at(3)->frontals() == KeyVector{X(3)});
-  EXPECT(hybridBayesNet2->at(3)->parents() == KeyVector({M(2), M(1)}));
+
+  EXPECT_LONGS_EQUAL(4, hybridBayesNet2.size());
+  // hybridBayesNet2.print();
+  EXPECT(hybridBayesNet2.at(2)->frontals() == KeyVector{X(2)});
+  EXPECT(hybridBayesNet2.at(2)->parents() == KeyVector({X(3), M(2), M(1)}));
+  EXPECT(hybridBayesNet2.at(3)->frontals() == KeyVector{X(3)});
+  EXPECT(hybridBayesNet2.at(3)->parents() == KeyVector({M(2), M(1)}));
 
   auto remainingFactorGraph2 = incrementalHybrid.remainingFactorGraph();
   CHECK(remainingFactorGraph2);
@@ -117,15 +117,15 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_inference) {
       switching.linearizedFactorGraph.eliminatePartialSequential(ordering);
 
   // The densities on X(1) should be the same
-  EXPECT(assert_equal(*(hybridBayesNet->atGaussian(0)),
+  EXPECT(assert_equal(*(hybridBayesNet.atGaussian(0)),
                       *(expectedHybridBayesNet->atGaussian(0))));
 
   // The densities on X(2) should be the same
-  EXPECT(assert_equal(*(hybridBayesNet2->atGaussian(2)),
+  EXPECT(assert_equal(*(hybridBayesNet2.atGaussian(2)),
                       *(expectedHybridBayesNet->atGaussian(1))));
 
   // The densities on X(3) should be the same
-  EXPECT(assert_equal(*(hybridBayesNet2->atGaussian(3)),
+  EXPECT(assert_equal(*(hybridBayesNet2.atGaussian(3)),
                       *(expectedHybridBayesNet->atGaussian(2))));
 
   // we only do the manual continuous elimination for 0,0
@@ -140,7 +140,7 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_inference) {
         dynamic_pointer_cast<DCGaussianMixtureFactor>(graph2.dcGraph().at(0));
     gf.add(dcMixture->factors()(m00));
     auto x2_mixed =
-        boost::dynamic_pointer_cast<GaussianMixture>(hybridBayesNet->at(1));
+        boost::dynamic_pointer_cast<GaussianMixture>(hybridBayesNet.at(1));
     gf.add(x2_mixed->factors()(m00));
     auto result_gf = gf.eliminateSequential();
     return gf.probPrime(result_gf->optimize());
@@ -248,14 +248,13 @@ TEST(DCGaussianElimination, Approx_inference) {
    */
   auto hybridBayesNet = incrementalHybrid.hybridBayesNet();
 
-  CHECK(hybridBayesNet);
-  EXPECT_LONGS_EQUAL(4, hybridBayesNet->size());
-  EXPECT_LONGS_EQUAL(2, hybridBayesNet->atGaussian(0)->nrComponents());
-  EXPECT_LONGS_EQUAL(4, hybridBayesNet->atGaussian(1)->nrComponents());
-  EXPECT_LONGS_EQUAL(8, hybridBayesNet->atGaussian(2)->nrComponents());
-  EXPECT_LONGS_EQUAL(5, hybridBayesNet->atGaussian(3)->nrComponents());
+  EXPECT_LONGS_EQUAL(4, hybridBayesNet.size());
+  EXPECT_LONGS_EQUAL(2, hybridBayesNet.atGaussian(0)->nrComponents());
+  EXPECT_LONGS_EQUAL(4, hybridBayesNet.atGaussian(1)->nrComponents());
+  EXPECT_LONGS_EQUAL(8, hybridBayesNet.atGaussian(2)->nrComponents());
+  EXPECT_LONGS_EQUAL(5, hybridBayesNet.atGaussian(3)->nrComponents());
 
-  auto &lastDensity = *(hybridBayesNet->atGaussian(3));
+  auto &lastDensity = *(hybridBayesNet.atGaussian(3));
   auto &unprunedLastDensity = *(unprunedHybridBayesNet->atGaussian(3));
   std::vector<std::pair<DiscreteValues, double>> assignments =
       discreteFactor_m1.enumerate();
@@ -302,7 +301,7 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_approximate) {
   size_t maxComponents = 5;
   incrementalHybrid.update(graph1, ordering, maxComponents);
 
-  auto &actualBayesNet1 = *incrementalHybrid.hybridBayesNet();
+  auto actualBayesNet1 = incrementalHybrid.hybridBayesNet();
   CHECK_EQUAL(4, actualBayesNet1.size());
   EXPECT_LONGS_EQUAL(2, actualBayesNet1.atGaussian(0)->nrComponents());
   EXPECT_LONGS_EQUAL(4, actualBayesNet1.atGaussian(1)->nrComponents());
@@ -319,7 +318,7 @@ TEST_UNSAFE(DCGaussianElimination, Incremental_approximate) {
 
   incrementalHybrid.update(graph2, ordering2, maxComponents);
 
-  auto &actualBayesNet = *incrementalHybrid.hybridBayesNet();
+  auto actualBayesNet = incrementalHybrid.hybridBayesNet();
   CHECK_EQUAL(2, actualBayesNet.size());
   EXPECT_LONGS_EQUAL(10, actualBayesNet.atGaussian(0)->nrComponents());
   EXPECT_LONGS_EQUAL(5, actualBayesNet.atGaussian(1)->nrComponents());


### PR DESCRIPTION
As per Frank's recommendation, converting shared_ptrs to plain old C++ objects (POCO) for vector-like containers.