### PR TITLE
Evaluate Hybrid Bayes Net

### DIFF
--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -6,11 +6,22 @@
 
 namespace gtsam {
 
-GaussianMixture::shared_ptr HybridBayesNet::atGaussian(size_t i) {
+GaussianMixture::shared_ptr HybridBayesNet::atGaussian(size_t i) const {
   return boost::dynamic_pointer_cast<GaussianMixture>(factors_.at(i));
 }
-DiscreteConditional::shared_ptr HybridBayesNet::atDiscrete(size_t i) {
+
+DiscreteConditional::shared_ptr HybridBayesNet::atDiscrete(size_t i) const {
   return boost::dynamic_pointer_cast<DiscreteConditional>(factors_.at(i));
 }
 
+GaussianBayesNet HybridBayesNet::operator()(
+    const DiscreteValues& assignment) const {
+  GaussianBayesNet gbn;
+  for (size_t idx = 0; idx < size(); idx++) {
+    GaussianMixture gm = *this->atGaussian(idx);
+    gbn.push_back(gm(assignment));
+  }
+  return gbn;
 }
+
+}  // namespace gtsam

--- a/gtsam/hybrid/HybridBayesNet.cpp
+++ b/gtsam/hybrid/HybridBayesNet.cpp
@@ -1,6 +1,20 @@
-//
-// Created by Fan Jiang on 1/24/22.
-//
+/* ----------------------------------------------------------------------------
+
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   HybridBayesNet.cpp
+ * @brief  A bayes net of Gaussian Conditionals indexed by discrete keys.
+ * @author Fan Jiang
+ * @date   January 2022
+ */
 
 #include <gtsam/hybrid/HybridBayesNet.h>
 
@@ -14,7 +28,7 @@ DiscreteConditional::shared_ptr HybridBayesNet::atDiscrete(size_t i) const {
   return boost::dynamic_pointer_cast<DiscreteConditional>(factors_.at(i));
 }
 
-GaussianBayesNet HybridBayesNet::operator()(
+GaussianBayesNet HybridBayesNet::choose(
     const DiscreteValues& assignment) const {
   GaussianBayesNet gbn;
   for (size_t idx = 0; idx < size(); idx++) {

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -24,6 +24,7 @@
 #include <gtsam/discrete/DiscreteKey.h>
 #include <gtsam/hybrid/GaussianMixture.h>
 #include <gtsam/inference/BayesNet.h>
+#include <gtsam/linear/GaussianBayesNet.h>
 #include <gtsam/linear/GaussianConditional.h>
 
 #include <iostream>  // TODO!
@@ -56,14 +57,16 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<AbstractConditional> {
    * (this checks array bounds and may throw an exception, as opposed to
    * operator[] which does not).
    */
-  GaussianMixture::shared_ptr atGaussian(size_t i);
+  GaussianMixture::shared_ptr atGaussian(size_t i) const;
 
   /**
    * Get a specific Gaussian mixture factor by index
    * (this checks array bounds and may throw an exception, as opposed to
    * operator[] which does not).
    */
-  DiscreteConditional::shared_ptr atDiscrete(size_t i);
+  DiscreteConditional::shared_ptr atDiscrete(size_t i) const;
+
+  GaussianBayesNet operator()(const DiscreteValues &assignment) const;
 };
 
 }  // namespace gtsam

--- a/gtsam/hybrid/HybridBayesNet.h
+++ b/gtsam/hybrid/HybridBayesNet.h
@@ -11,7 +11,7 @@
 
 /**
  * @file    HybridBayesNet.h
- * @brief   A set of GaussianFactors, indexed by a set of discrete keys.
+ * @brief   A bayes net of Gaussian Conditionals indexed by discrete keys.
  * @author  Varun Agrawal
  * @author  Fan Jiang
  * @author  Frank Dellaert
@@ -66,7 +66,7 @@ class GTSAM_EXPORT HybridBayesNet : public BayesNet<AbstractConditional> {
    */
   DiscreteConditional::shared_ptr atDiscrete(size_t i) const;
 
-  GaussianBayesNet operator()(const DiscreteValues &assignment) const;
+  GaussianBayesNet choose(const DiscreteValues &assignment) const;
 };
 
 }  // namespace gtsam


### PR DESCRIPTION
This PR adds `operator()` for computing a `GaussianBayesNet` from a `HybridBayesNet` given a specific assignment. 