### PR TITLE
Fix discrete graph indexing

### DIFF
--- a/gtsam/hybrid/IncrementalHybrid.cpp
+++ b/gtsam/hybrid/IncrementalHybrid.cpp
@@ -88,6 +88,9 @@ void IncrementalHybrid::update(GaussianHybridFactorGraph graph,
     const auto lastDensity =
         boost::dynamic_pointer_cast<GaussianMixture>(hybridBayesNet_.back());
 
+    // Check if discreteGraph exists. Possible that `update` had no DCFactors or Discrete Factors.
+    if (remainingFactorGraph_.discreteGraph().size() == 0) return;
+
     auto discreteFactor = boost::dynamic_pointer_cast<DecisionTreeFactor>(
         remainingFactorGraph_.discreteGraph().at(0));
 


### PR DESCRIPTION
Add check for discrete graph size so that we don't get an out of bounds exception.

This is why pruning was failing for me yesterday. Going to figure out why pruning isn't happening correctly now.